### PR TITLE
Quick Settings: Tile animations setSelectable -> setEnabled

### DIFF
--- a/src/com/gzr/wolvesden/fragments/QuickSettings.java
+++ b/src/com/gzr/wolvesden/fragments/QuickSettings.java
@@ -360,11 +360,11 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
     private void updateAnimTileStyle(int tileAnimationStyle) {
         if (mTileAnimationDuration != null) {
             if (tileAnimationStyle == 0) {
-                mTileAnimationDuration.setSelectable(false);
-                mTileAnimationInterpolator.setSelectable(false);
+                mTileAnimationDuration.setEnabled(false);
+                mTileAnimationInterpolator.setEnabled(false);
             } else {
-                mTileAnimationDuration.setSelectable(true);
-                mTileAnimationInterpolator.setSelectable(true);
+                mTileAnimationDuration.setEnabled(true);
+                mTileAnimationInterpolator.setEnabled(true);
             }
         }
     }


### PR DESCRIPTION
 * With setSelectable enabled, when no tile animation is set, the options
 for Tile animation duration and Tile animation interpolator simply become
 unclickable. With setEnabled used, these options become grayed out and
 unclickable, thus seeming properly disabled.

Signed-off-by: Raleigh Matlock <raleighman2@gmail.com>